### PR TITLE
Add url attachment to card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ If you are missing some fonctionnalities, you can easily contribute and propose 
 | PUT /1/cards/[card id or shortlink]/warnWhenUpcoming
 | POST /1/cards | ![](http://icdn.pro/images/fr/v/e/verifier-vert-ok-icone-8505-48.png)
 | POST /1/cards/[card id or shortlink]/actions/comments | ![](http://icdn.pro/images/fr/v/e/verifier-vert-ok-icone-8505-48.png)
-| POST /1/cards/[card id or shortlink]/attachments
+| POST /1/cards/[card id or shortlink]/attachments | ![](http://icdn.pro/images/fr/v/e/verifier-vert-ok-icone-8505-48.png)
 | POST /1/cards/[card id or shortlink]/checklist/[idChecklist]/checkItem
 | POST /1/cards/[card id or shortlink]/checklist/[idChecklist]/checkItem/[idCheckItem]/convertToCard
 | POST /1/cards/[card id or shortlink]/checklists

--- a/src/main/java/com/julienvey/trello/Trello.java
+++ b/src/main/java/com/julienvey/trello/Trello.java
@@ -84,6 +84,8 @@ public interface Trello {
 
     void addCommentToCard(String idCard, String comment);
 
+    void addUrlAttachmentToCard(String idCard, String url);
+
     Card updateCard(Card card);
 
     //FIXME Remove this method

--- a/src/main/java/com/julienvey/trello/domain/Attachment.java
+++ b/src/main/java/com/julienvey/trello/domain/Attachment.java
@@ -18,6 +18,12 @@ public class Attachment extends TrelloEntity {
     private List<Preview> previews;
     private String url;
 
+    public Attachment() {}
+
+    public Attachment(String url) {
+        this.url = url;
+    }
+
     public int getBytes() {
         return bytes;
     }

--- a/src/main/java/com/julienvey/trello/impl/TrelloImpl.java
+++ b/src/main/java/com/julienvey/trello/impl/TrelloImpl.java
@@ -326,6 +326,11 @@ public class TrelloImpl implements Trello {
     }
 
     @Override
+    public void addUrlAttachmentToCard(String idCard, String url) {
+        postForObject(createUrl(ADD_URL_ATTACHMENT_TO_CARD).asString(), new Attachment(url), Attachment.class, idCard);
+    }
+
+    @Override
     public Card updateCard(Card card) {
         Card put = put(createUrl(UPDATE_CARD).asString(), card, Card.class, card.getId());
         put.setInternalTrello(this);

--- a/src/main/java/com/julienvey/trello/impl/TrelloUrl.java
+++ b/src/main/java/com/julienvey/trello/impl/TrelloUrl.java
@@ -44,6 +44,7 @@ public class TrelloUrl {
     public static final String GET_MEMBER = "/members/{username}?";
     public static final String ADD_LABEL_TO_CARD = "/cards/{cardId}/labels?";
     public static final String ADD_COMMENT_TO_CARD = "/cards/{cardId}/actions/comments?";
+    public static final String ADD_URL_ATTACHMENT_TO_CARD = "/cards/{cardId}/attachments?";
 
     public static final String UPDATE_CARD = "/cards/{cardId}?";
 


### PR DESCRIPTION
This adds the ability to add a URL attachment to a card via a POST to the Trello /card/{id}/attachment endpoint