### PR TITLE
better error reporting for errors reported by Trello REST API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 group = 'com.taskadapter'
-version = '0.6'
+version = '0.7-SNAPSHOT'
 
 description = """Trello Java Wrapper"""
 

--- a/src/main/java/com/julienvey/trello/NotFoundException.java
+++ b/src/main/java/com/julienvey/trello/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.julienvey.trello;
+
+public final class NotFoundException extends TrelloBadRequestException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/julienvey/trello/impl/TrelloImpl.java
+++ b/src/main/java/com/julienvey/trello/impl/TrelloImpl.java
@@ -47,6 +47,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.julienvey.trello.ListNotFoundException;
+import com.julienvey.trello.NotFoundException;
 import com.julienvey.trello.TrelloBadRequestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -415,9 +416,11 @@ public class TrelloImpl implements Trello {
     private static TrelloBadRequestException decodeException(Card card, TrelloBadRequestException e) {
         if (e.getMessage().contains("invalid value for idList")) {
             return new ListNotFoundException(card.getIdList());
-        } else {
-            return e;
         }
+        if (e instanceof NotFoundException) {
+            return new NotFoundException("Card with id " + card.getId() + " is not found. It may have been deleted in Trello");
+        }
+        return e;
     }
 
     @Override

--- a/src/test/scala/com/julienvey/trello/CardIt.scala
+++ b/src/test/scala/com/julienvey/trello/CardIt.scala
@@ -12,7 +12,7 @@ class CardIt extends FunSpec with Matchers {
   val validListIdFromSomeoneElsesAccount = "518baad5b05dbf4703004853"
   val unknownListId = "someUnknownId"
 
-  describe("card API") {
+  describe("create API") {
     it("gets user-friendly error when list id unknown") {
       val thrown = intercept[ListNotFoundException] {
         trello.createCard(unknownListId, new Card())
@@ -38,4 +38,18 @@ class CardIt extends FunSpec with Matchers {
       created.getName shouldBe "card created without board id"
     }
   }
+
+  describe("update API") {
+    it("gets user-friendly exception when updating a deleted card") {
+      val thrown = intercept[NotFoundException] {
+        val card = new Card()
+        card.setId("5b2345c87e570f053e606ebf") // deleted card ID
+        card.setName("deleted card that should not be updated")
+        card.setIdList(TrelloConfig.toDoListId)
+        trello.updateCard(card)
+      }
+      thrown.getMessage should include("not found")
+    }
+  }
+
 }


### PR DESCRIPTION
1. return http response text provided by Trello when json parsing fails
2. wrap "404 not found" into a new exception: NotFoundException
the new exception has a user-friendly message