### PR TITLE
Don't depend on logback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 .classpath
 .project
 .settings
+/.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,6 @@ dependencies {
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version:'2.2.0'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.2.0'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version:'2.2.0'
-    compile group: 'ch.qos.logback', name: 'logback-core', version:'1.0.11'
-    compile group: 'ch.qos.logback', name: 'logback-classic', version:'1.0.11'
     compile group: 'org.slf4j', name: 'slf4j-api', version:'1.7.5'
     compile group: 'org.springframework', name: 'spring-web', version:'3.2.2.RELEASE'
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: httpClientVersion


### PR DESCRIPTION
Libraries are not intended to choose the [SLF4J implementation](https://www.slf4j.org/manual.html#swapping); that's a deploy-time decision for the consumer.