### PR TITLE
Fix compiler warnings about ambiguous varargs invocation

### DIFF
--- a/src/main/java/com/julienvey/trello/impl/http/RestTemplateHttpClient.java
+++ b/src/main/java/com/julienvey/trello/impl/http/RestTemplateHttpClient.java
@@ -20,17 +20,16 @@ public class RestTemplateHttpClient implements TrelloHttpClient {
     @Override
     public <T> T postForObject(String url, T object, Class<T> objectClass, String... params) {
         try {
-            return restTemplate.postForObject(url, object, objectClass, params);
+            return restTemplate.postForObject(url, object, objectClass, (Object[]) params);
         } catch (RestClientException e) {
             throw new TrelloHttpException(e);
         }
-
     }
 
     @Override
     public URI postForLocation(String url, Object object, String... params) {
         try {
-            return restTemplate.postForLocation(url, object, params);
+            return restTemplate.postForLocation(url, object, (Object[]) params);
         } catch (RestClientException e) {
             throw new TrelloHttpException(e);
         }
@@ -39,7 +38,7 @@ public class RestTemplateHttpClient implements TrelloHttpClient {
     @Override
     public <T> T get(String url, Class<T> objectClass, String... params) {
         try {
-            return restTemplate.getForObject(url, objectClass, params);
+            return restTemplate.getForObject(url, objectClass, (Object[]) params);
         } catch (RestClientException e) {
             throw new TrelloHttpException(e);
         }
@@ -48,7 +47,8 @@ public class RestTemplateHttpClient implements TrelloHttpClient {
     @Override
     public <T> T putForObject(String url, T object, Class<T> objectClass, String... params) {
         try {
-            return restTemplate.exchange(url, HttpMethod.PUT, new HttpEntity<>(object), objectClass, params).getBody();
+            return restTemplate.exchange(url, HttpMethod.PUT, new HttpEntity<>(object), objectClass, (Object[]) params)
+                    .getBody();
         } catch (RestClientException e) {
             throw new TrelloHttpException(e);
         }


### PR DESCRIPTION
Warnings are like this:

```
warning: non-varargs call of varargs method with inexact argument type for last parameter;
            return restTemplate.postForObject(url, object, objectClass, params);
                                                                        ^
  cast to Object for a varargs call
  cast to Object[] for a non-varargs call and to suppress this warning
```

I'm guessing that `Object[]` is the flavor that should be used?