### PR TITLE
TrelloHttpClient for the modern version of the Async Http Client.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,20 +31,23 @@ ext {
     scalaBinaryVersion = '2.12'
     scalaFullVersion = '2.12.2'
     httpClientVersion = '4.2.5'
+    jacksonVersion = '2.9.6'
 }
 
 dependencies {
 
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version:'2.2.0'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.2.0'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version:'2.2.0'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version:jacksonVersion
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:jacksonVersion
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version:jacksonVersion
     compile group: 'org.slf4j', name: 'slf4j-api', version:'1.7.5'
     compile group: 'org.springframework', name: 'spring-web', version:'3.2.2.RELEASE'
     compileOnly group: 'org.apache.httpcomponents', name: 'httpclient', version: httpClientVersion
     compileOnly group: 'com.ning', name: 'async-http-client', version:'1.7.19'
+    compileOnly group: 'org.asynchttpclient', name: 'async-http-client', version:'2.5.2'
 
     testImplementation group: 'org.apache.httpcomponents', name: 'httpclient', version: httpClientVersion
     testImplementation group: 'com.ning', name: 'async-http-client', version:'1.7.19'
+    testImplementation group: 'org.asynchttpclient', name: 'async-http-client', version:'2.5.2'
 
     implementation (
         "org.apache.httpcomponents:httpmime:${httpClientVersion}"

--- a/src/main/java/com/julienvey/trello/domain/Label.java
+++ b/src/main/java/com/julienvey/trello/domain/Label.java
@@ -5,10 +5,19 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Label extends TrelloEntity {
 
+    private String id;
     private String color;
     private String name;
 
     /* Accessors */
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
     public String getColor() {
         return color;
     }

--- a/src/main/java/com/julienvey/trello/impl/http/AsyncTrelloHttpClient2.java
+++ b/src/main/java/com/julienvey/trello/impl/http/AsyncTrelloHttpClient2.java
@@ -1,0 +1,138 @@
+package com.julienvey.trello.impl.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.julienvey.trello.exception.TrelloHttpException;
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.asynchttpclient.AsyncCompletionHandler;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.DefaultAsyncHttpClient;
+import org.asynchttpclient.Response;
+
+/**
+ * TrelloHttpClient based on the org.asynchttpclient HTTP client, the successor to the ning async http client.
+ */
+public class AsyncTrelloHttpClient2 extends AbstractHttpClient {
+
+    private final AsyncHttpClient asyncHttpClient;
+    private final ObjectReader reader;
+    private final ObjectWriter writer;
+
+    public AsyncTrelloHttpClient2() {
+        this(new DefaultAsyncHttpClient(), new ObjectMapper());
+    }
+
+    public AsyncTrelloHttpClient2(AsyncHttpClient asyncHttpClient, ObjectMapper mapper) {
+        this(asyncHttpClient, mapper.reader(), mapper.writer());
+    }
+
+    public AsyncTrelloHttpClient2(AsyncHttpClient asyncHttpClient, ObjectReader reader, ObjectWriter writer) {
+        this.asyncHttpClient = asyncHttpClient;
+        this.reader = reader;
+        this.writer = writer;
+    }
+
+    @Override
+    public <T> T get(String url, final Class<T> objectClass, String... params) {
+        Future<T> f;
+        try {
+            f = asyncHttpClient.prepareGet(expandUrl(url, params)).execute(
+                    new AsyncCompletionHandler<T>() {
+
+                        @Override
+                        public T onCompleted(Response response) throws Exception {
+                            return reader.forType(objectClass).readValue(response.getResponseBody());
+                        }
+
+                        @Override
+                        public void onThrowable(Throwable t) {
+                            throw new TrelloHttpException(t);
+                        }
+                    });
+            return f.get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new TrelloHttpException(e);
+        }
+    }
+
+    @Override
+    public <T> T postForObject(String url, T object, final Class<T> objectClass, String... params) {
+        Future<T> f;
+        try {
+            byte[] body = this.writer.writeValueAsBytes(object);
+            f = asyncHttpClient.preparePost(expandUrl(url, params)).setBody(body).execute(
+                    new AsyncCompletionHandler<T>() {
+
+                        @Override
+                        public T onCompleted(Response response) throws Exception {
+                            return reader.forType(objectClass).readValue(response.getResponseBody());
+                        }
+
+                        @Override
+                        public void onThrowable(Throwable t) {
+                            throw new TrelloHttpException(t);
+                        }
+                    });
+            return f.get();
+        } catch (IOException | InterruptedException | ExecutionException e) {
+            throw new TrelloHttpException(e);
+        }
+    }
+
+    @Override
+    public URI postForLocation(String url, Object object, String... params) {
+        Future<URI> f;
+        try {
+            byte[] body = this.writer.writeValueAsBytes(object);
+            f = asyncHttpClient.preparePost(expandUrl(url, params)).setBody(body).execute(
+                    new AsyncCompletionHandler<URI>() {
+
+                        @Override
+                        public URI onCompleted(Response response) {
+                            String location = response.getHeader("Location");
+                            if (location != null) {
+                                return URI.create(location);
+                            } else {
+                                throw new TrelloHttpException("Location header not set");
+                            }
+                        }
+
+                        @Override
+                        public void onThrowable(Throwable t) {
+                            throw new TrelloHttpException(t);
+                        }
+                    });
+            return f.get();
+        } catch (IOException | InterruptedException | ExecutionException e) {
+            throw new TrelloHttpException(e);
+        }
+    }
+
+    @Override
+    public <T> T putForObject(String url, T object, final Class<T> objectClass, String... params) {
+        Future<T> f;
+        try {
+            byte[] body = this.writer.writeValueAsBytes(object);
+            f = asyncHttpClient.preparePut(expandUrl(url, params)).setBody(body).execute(
+                    new AsyncCompletionHandler<T>() {
+
+                        @Override
+                        public T onCompleted(Response response) throws Exception {
+                            return reader.forType(objectClass).readValue(response.getResponseBody());
+                        }
+
+                        @Override
+                        public void onThrowable(Throwable t) {
+                            throw new TrelloHttpException(t);
+                        }
+                    });
+            return f.get();
+        } catch (IOException | InterruptedException | ExecutionException e) {
+            throw new TrelloHttpException(e);
+        }
+    }
+}

--- a/src/test/java/com/julienvey/trello/integration/ActionGetITCase.java
+++ b/src/test/java/com/julienvey/trello/integration/ActionGetITCase.java
@@ -6,9 +6,9 @@ import com.julienvey.trello.domain.*;
 import com.julienvey.trello.impl.TrelloImpl;
 import com.julienvey.trello.impl.http.ApacheHttpClient;
 import com.julienvey.trello.impl.http.AsyncTrelloHttpClient;
+import com.julienvey.trello.impl.http.AsyncTrelloHttpClient2;
 import com.julienvey.trello.impl.http.RestTemplateHttpClient;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -31,7 +31,8 @@ public class ActionGetITCase {
 
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{{new ApacheHttpClient()}, {new AsyncTrelloHttpClient()}, {new RestTemplateHttpClient()}});
+        return Arrays.asList(new Object[][]{{new ApacheHttpClient()}, {new AsyncTrelloHttpClient()},
+                {new RestTemplateHttpClient()}, {new AsyncTrelloHttpClient2()}});
     }
 
     public ActionGetITCase(TrelloHttpClient httpClient) {

--- a/src/test/java/com/julienvey/trello/integration/BoardGetITCase.java
+++ b/src/test/java/com/julienvey/trello/integration/BoardGetITCase.java
@@ -28,6 +28,7 @@ import com.julienvey.trello.domain.TList;
 import com.julienvey.trello.impl.TrelloImpl;
 import com.julienvey.trello.impl.http.ApacheHttpClient;
 import com.julienvey.trello.impl.http.AsyncTrelloHttpClient;
+import com.julienvey.trello.impl.http.AsyncTrelloHttpClient2;
 import com.julienvey.trello.impl.http.RestTemplateHttpClient;
 
 @RunWith(Parameterized.class)
@@ -42,7 +43,8 @@ public class BoardGetITCase {
 
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] { { new ApacheHttpClient() }, { new AsyncTrelloHttpClient() }, { new RestTemplateHttpClient() } });
+        return Arrays.asList(new Object[][]{{new ApacheHttpClient()}, {new AsyncTrelloHttpClient()},
+                {new RestTemplateHttpClient()}, {new AsyncTrelloHttpClient2()}});
     }
 
     public BoardGetITCase(TrelloHttpClient httpClient) {

--- a/src/test/java/com/julienvey/trello/integration/CardGetITCase.java
+++ b/src/test/java/com/julienvey/trello/integration/CardGetITCase.java
@@ -22,6 +22,7 @@ import com.julienvey.trello.domain.CheckList;
 import com.julienvey.trello.impl.TrelloImpl;
 import com.julienvey.trello.impl.http.ApacheHttpClient;
 import com.julienvey.trello.impl.http.AsyncTrelloHttpClient;
+import com.julienvey.trello.impl.http.AsyncTrelloHttpClient2;
 import com.julienvey.trello.impl.http.RestTemplateHttpClient;
 
 @RunWith(Parameterized.class)
@@ -36,7 +37,7 @@ public class CardGetITCase {
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] { { new ApacheHttpClient() }, { new AsyncTrelloHttpClient() },
-                { new RestTemplateHttpClient() } });
+                { new RestTemplateHttpClient() }, { new AsyncTrelloHttpClient2() } });
     }
 
     public CardGetITCase(TrelloHttpClient httpClient) {

--- a/src/test/java/com/julienvey/trello/integration/CheckListGetITCase.java
+++ b/src/test/java/com/julienvey/trello/integration/CheckListGetITCase.java
@@ -6,6 +6,7 @@ import com.julienvey.trello.domain.CheckList;
 import com.julienvey.trello.impl.TrelloImpl;
 import com.julienvey.trello.impl.http.ApacheHttpClient;
 import com.julienvey.trello.impl.http.AsyncTrelloHttpClient;
+import com.julienvey.trello.impl.http.AsyncTrelloHttpClient2;
 import com.julienvey.trello.impl.http.RestTemplateHttpClient;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,7 +30,8 @@ public class CheckListGetITCase {
 
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{{new ApacheHttpClient()}, {new AsyncTrelloHttpClient()}, {new RestTemplateHttpClient()}});
+        return Arrays.asList(new Object[][]{{new ApacheHttpClient()}, {new AsyncTrelloHttpClient()},
+                {new RestTemplateHttpClient()}, {new AsyncTrelloHttpClient2()}});
     }
 
     public CheckListGetITCase(TrelloHttpClient httpClient) {

--- a/src/test/java/com/julienvey/trello/integration/ListGetITCase.java
+++ b/src/test/java/com/julienvey/trello/integration/ListGetITCase.java
@@ -18,6 +18,7 @@ import com.julienvey.trello.domain.TList;
 import com.julienvey.trello.impl.TrelloImpl;
 import com.julienvey.trello.impl.http.ApacheHttpClient;
 import com.julienvey.trello.impl.http.AsyncTrelloHttpClient;
+import com.julienvey.trello.impl.http.AsyncTrelloHttpClient2;
 import com.julienvey.trello.impl.http.RestTemplateHttpClient;
 
 @RunWith(Parameterized.class)
@@ -32,7 +33,8 @@ public class ListGetITCase {
 
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] { { new ApacheHttpClient() }, { new AsyncTrelloHttpClient() }, { new RestTemplateHttpClient() } });
+        return Arrays.asList(new Object[][]{{new ApacheHttpClient()}, {new AsyncTrelloHttpClient()},
+                {new RestTemplateHttpClient()}, {new AsyncTrelloHttpClient2()}});
     }
 
     public ListGetITCase(TrelloHttpClient httpClient) {

--- a/src/test/java/com/julienvey/trello/integration/OrganizationGetITCase.java
+++ b/src/test/java/com/julienvey/trello/integration/OrganizationGetITCase.java
@@ -18,6 +18,7 @@ import com.julienvey.trello.domain.Member;
 import com.julienvey.trello.impl.TrelloImpl;
 import com.julienvey.trello.impl.http.ApacheHttpClient;
 import com.julienvey.trello.impl.http.AsyncTrelloHttpClient;
+import com.julienvey.trello.impl.http.AsyncTrelloHttpClient2;
 import com.julienvey.trello.impl.http.RestTemplateHttpClient;
 
 @RunWith(Parameterized.class)
@@ -32,7 +33,8 @@ public class OrganizationGetITCase {
 
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] { { new ApacheHttpClient() }, { new AsyncTrelloHttpClient() }, { new RestTemplateHttpClient() } });
+        return Arrays.asList(new Object[][]{{new ApacheHttpClient()}, {new AsyncTrelloHttpClient()},
+                {new RestTemplateHttpClient()}, {new AsyncTrelloHttpClient2()}});
     }
 
     public OrganizationGetITCase(TrelloHttpClient httpClient) {


### PR DESCRIPTION
I'm open to suggestions for the name of the class... the current one is pretty ugly but I couldn't think of anything better.

Also, bump jackson version to the current version, and give Label
accessors for its id attribute.

The implementation is almost identical to the one for the old ning AHC client. It uses final `ObjectReader` and `ObjectWriter` fields as those are preferable to the mutable `ObjectMapper` type. 