### PR TITLE
Add getMemberInformation without parameters method

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ The new test code is implemented using Scala. The prod code is only Java - to av
 | PUT /1/lists/[idList]/subscribed
 | POST /1/lists
 | POST /1/lists/[idList]/cards
+| GET /1/members/me | Yes | Yes
 | GET /1/members/[idMember or username] | Yes
 | GET /1/members/[idMember or username]/[field]
 | GET /1/members/[idMember or username]/actions | Yes | Yes | Yes

--- a/src/main/java/com/julienvey/trello/Trello.java
+++ b/src/main/java/com/julienvey/trello/Trello.java
@@ -258,6 +258,8 @@ public interface Trello {
 
     Member getMemberInformation(String username);
 
+    Member getMemberInformation();
+
     List<Board> getMemberBoards(String userId, Argument... args);
 
     List<Card> getMemberCards(String userId, Argument... args);

--- a/src/main/java/com/julienvey/trello/impl/TrelloImpl.java
+++ b/src/main/java/com/julienvey/trello/impl/TrelloImpl.java
@@ -495,6 +495,13 @@ public class TrelloImpl implements Trello {
     }
 
     @Override
+    public Member getMemberInformation() {
+        Member member = get(createUrl(GET_MEMBER).asString(), Member.class, "me");
+        member.setInternalTrello(this);
+        return member;
+    }
+
+    @Override
     public List<Board> getMemberBoards(String userId, Argument... args) {
         return asList(() -> get(createUrl(GET_MEMBER_BOARDS).params(args).asString(), Board[].class, userId));
     }

--- a/src/test/java/com/julienvey/trello/unit/MemberGetUnitTest.java
+++ b/src/test/java/com/julienvey/trello/unit/MemberGetUnitTest.java
@@ -4,6 +4,7 @@ import com.julienvey.trello.Trello;
 import com.julienvey.trello.TrelloHttpClient;
 import com.julienvey.trello.domain.Action;
 import com.julienvey.trello.domain.Board;
+import com.julienvey.trello.domain.Member;
 import com.julienvey.trello.impl.TrelloImpl;
 import org.junit.Before;
 import org.junit.Test;
@@ -79,6 +80,26 @@ public class MemberGetUnitTest {
 
         verify(httpClient).get(eq("https://api.trello.com/1/members/{userId}/actions?key={applicationKey}&token={userToken}"),
                 eq(Action[].class), eq("idMember"), eq(""), eq(""));
+        verifyNoMoreInteractions(httpClient);
+    }
+
+    @Test
+    public void testGetMemberInformation() {
+        // Given
+        Member expected = new Member();
+
+        when(httpClient.get(anyString(), any(Class.class), (String[]) anyVararg())).thenReturn(expected);
+
+        // When
+        Member member = trello.getMemberInformation();
+
+        // Then
+        assertThat(member)
+                .isNotNull()
+                .isEqualTo(expected);
+
+        verify(httpClient).get(eq("https://api.trello.com/1/members/{username}?key={applicationKey}&token={userToken}"),
+                eq(Member.class), eq("me"), eq(""), eq(""));
         verifyNoMoreInteractions(httpClient);
     }
 }


### PR DESCRIPTION
This method is used to retrieve member's information of the current user accessing the API.
The endpoint is '/1/members/me' and it isn't documented on Trello's API but it is available.