### PR TITLE
Make Jitpack compile using JDK11

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+- openjdk11


### PR DESCRIPTION
Allows using Jitpack.io instead of the (now deprecated) JCenter